### PR TITLE
Add pylint CI workflow and fix all lint issues

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -26,29 +26,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pylint
-      - name: Lint all functions
+      - name: Install function dependencies
         run: |
-          # Find all subdirectories in functions/ that contain Python files
           for func_dir in functions/*/; do
-            if [ -d "$func_dir" ] && find "$func_dir" -name "*.py" -type f | grep -q .; then
-              func_name=$(basename "$func_dir")
-              echo "::group::Processing $func_name"
-
-              # Install function-specific dependencies if requirements.txt exists
-              if [ -f "$func_dir/requirements.txt" ]; then
-                echo "Installing dependencies for $func_name..."
-                pip install -r "$func_dir/requirements.txt"
-              else
-                echo "No requirements.txt found for $func_name, skipping dependency installation"
-              fi
-
-              # Run pylint on the function directory
-              echo "Running pylint on $func_name..."
-              pylint "$func_dir" --max-line-length=127 --disable=R0801 --py-version=${{ env.PYTHON_VERSION }} || {
-                echo "::error::Pylint failed for $func_name"
-                exit 1
-              }
-
-              echo "::endgroup::"
+            if [ -f "$func_dir/requirements.txt" ]; then
+              pip install -r "$func_dir/requirements.txt"
             fi
           done
+      - name: Lint all functions
+        run: |
+          pylint --recursive=y functions/ --max-line-length=127 --disable=R0801 --py-version=${{ env.PYTHON_VERSION }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,54 @@
+name: Pylint
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: '3.13'
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install global dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pylint
+      - name: Lint all functions
+        run: |
+          # Find all subdirectories in functions/ that contain Python files
+          for func_dir in functions/*/; do
+            if [ -d "$func_dir" ] && find "$func_dir" -name "*.py" -type f | grep -q .; then
+              func_name=$(basename "$func_dir")
+              echo "::group::Processing $func_name"
+
+              # Install function-specific dependencies if requirements.txt exists
+              if [ -f "$func_dir/requirements.txt" ]; then
+                echo "Installing dependencies for $func_name..."
+                pip install -r "$func_dir/requirements.txt"
+              else
+                echo "No requirements.txt found for $func_name, skipping dependency installation"
+              fi
+
+              # Run pylint on the function directory
+              echo "Running pylint on $func_name..."
+              pylint "$func_dir" --max-line-length=127 --disable=R0801 --py-version=${{ env.PYTHON_VERSION }} || {
+                echo "::error::Pylint failed for $func_name"
+                exit 1
+              }
+
+              echo "::endgroup::"
+            fi
+          done

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,607 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, checkers without error messages are disabled and for others,
+# only the ERROR messages are displayed, and no reports are done by default.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths. The default value ignores Emacs file
+# locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.13
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        duplicate-code
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the 'python-enchant' package.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=127
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# Number of positional arguments to a method
+max-positional-arguments=20
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=12
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=15
+
+# Maximum number of locals for function / method body.
+max-locals=20
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=30
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=

--- a/functions/ti-import-to-ng-siem/main.py
+++ b/functions/ti-import-to-ng-siem/main.py
@@ -1,13 +1,16 @@
+"""Threat intelligence feed importer for CrowdStrike Falcon Next-Gen SIEM."""
+
+import csv
+import ipaddress
+import os
+import tempfile
+from typing import Dict
+
 from crowdstrike.foundry.function import APIError, Function, Request, Response
 from falconpy import NGSIEM
 import requests
-import tempfile
-import os
-import ipaddress
-import csv
-from typing import Dict
 
-func = Function.instance()
+FUNC = Function.instance()
 
 # Define the files to process
 FILES_TO_PROCESS = [
@@ -49,82 +52,95 @@ FILES_TO_PROCESS = [
     }
 ]
 
+
 def is_valid_ipv4(ip_string):
+    """Check whether the given string is a valid IPv4 address."""
     try:
         ipaddress.IPv4Address(ip_string)
         return True
-    except:
+    except ValueError:
         return False
 
+
+def _process_lines_with_separator(lines, file_info):
+    """Parse lines that use a separator to split value and description."""
+    rows = []
+    separator = file_info["separator"]
+    is_ip = file_info["name"].startswith("ip-")
+    for line in lines:
+        if not line or line.startswith('#'):
+            continue
+        if is_ip and not is_valid_ipv4(line.split(separator)[0].strip()):
+            continue
+        parts = line.split(separator)
+        if len(parts) == 2:
+            rows.append([parts[0].strip(), parts[1].strip()])
+        else:
+            rows.append([parts[0].strip(), ""])
+    return rows
+
+
+def _process_lines_single_column(lines, file_info):
+    """Parse lines that contain a single value per row."""
+    rows = []
+    is_ip = file_info["name"].startswith("ip-")
+    for line in lines:
+        if not line or line.startswith('#'):
+            continue
+        if is_ip:
+            if is_valid_ipv4(line.strip()):
+                rows.append([line.strip()])
+        else:
+            rows.append([line.strip()])
+    return rows
+
+
 def process_file(file_info, temp_dir):
+    """Download a TI feed, parse it into CSV rows, and write to a temp file."""
     try:
-        # Download file
-        response = requests.get(file_info["url"])
+        response = requests.get(file_info["url"], timeout=60)
         response.raise_for_status()
 
-        # Read content
         content = response.text.strip()
         lines = content.splitlines()
 
-        # Process based on file type
-        output_rows = []
-
         if file_info["separator"]:
-            # For files with separators
-            for line in lines:
-                if line and not line.startswith('#'):
-                    if file_info["name"].startswith("ip-") and not is_valid_ipv4(line.split(file_info["separator"])[0].strip()):
-                        continue
-                    parts = line.split(file_info["separator"])
-                    if len(parts) == 2:
-                        output_rows.append([parts[0].strip(), parts[1].strip()])
-                    else:
-                        output_rows.append([parts[0].strip(), ""])
+            output_rows = _process_lines_with_separator(lines, file_info)
         else:
-            # For single column files
-            for line in lines:
-                if line and not line.startswith('#'):
-                    if file_info["name"].startswith("ip-"):
-                        if is_valid_ipv4(line.strip()):
-                            output_rows.append([line.strip()])
-                    else:
-                        output_rows.append([line.strip()])
+            output_rows = _process_lines_single_column(lines, file_info)
 
-        # Skip upload if feed returned no data rows
         if not output_rows:
             return None
 
-        # Write to CSV
         output_filename = f"ti_{file_info['name']}.csv"
         output_path = os.path.join(temp_dir, output_filename)
-        with open(output_path, 'w', newline='') as csvfile:
+        with open(output_path, 'w', newline='', encoding='utf-8') as csvfile:
             writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
             writer.writerow(file_info["headers"])
             writer.writerows(output_rows)
 
         return output_path
-    except Exception as e:
-        raise Exception(f"Error processing {file_info['name']}: {str(e)}")
+    except (requests.RequestException, OSError, ValueError) as e:
+        raise RuntimeError(
+            f"Error processing {file_info['name']}: {e}"
+        ) from e
 
-@func.handler(method='POST', path='/ti-import-bulk')
-def next_gen_siem_csv_import(request: Request, config: Dict[str, object] | None, logger) -> Response:
+
+@FUNC.handler(method='POST', path='/ti-import-bulk')
+def next_gen_siem_csv_import(request: Request, _config: Dict[str, object] | None, logger) -> Response:
+    """Handle bulk TI feed import and upload to Falcon Next-Gen SIEM."""
     try:
-        # Get parameters
         repository = request.body.get('repository', 'search-all').strip()
-
-        # Initialize NGSIEM client
         ngsiem = NGSIEM()
 
-        # Create temporary directory
         with tempfile.TemporaryDirectory() as temp_dir:
             results = []
 
-            # Process each file
             for file_info in FILES_TO_PROCESS:
                 try:
                     output_path = process_file(file_info, temp_dir)
                     if output_path is None:
-                        logger.info(f"No data rows for {file_info['name']}, skipping upload")
+                        logger.info("No data rows for %s, skipping upload", file_info['name'])
                         results.append({
                             "file": file_info["name"],
                             "status": "skipped",
@@ -135,9 +151,7 @@ def next_gen_siem_csv_import(request: Request, config: Dict[str, object] | None,
                         raise FileNotFoundError("File does not exist")
 
                     response = ngsiem.upload_file(lookup_file=output_path, repository=repository)
-
-                    # Log the raw response for troubleshooting
-                    logger.info(f"API response: {response}")
+                    logger.info("API response: %s", response)
 
                     if response["status_code"] >= 400:
                         error_messages = response.get("body", {}).get("errors", [])
@@ -151,9 +165,9 @@ def next_gen_siem_csv_import(request: Request, config: Dict[str, object] | None,
                     results.append({
                         "file": output_path,
                         "status": "success",
-                        "message": f"File processed and uploaded successfully"
+                        "message": "File processed and uploaded successfully"
                     })
-                except Exception as e:
+                except (RuntimeError, OSError, requests.RequestException, KeyError) as e:
                     results.append({
                         "file": file_info["name"],
                         "status": "error",
@@ -165,11 +179,12 @@ def next_gen_siem_csv_import(request: Request, config: Dict[str, object] | None,
             code=200
         )
 
-    except Exception as e:
+    except (AttributeError, TypeError, ValueError) as e:
         return Response(
             errors=[APIError(code=500, message=str(e))],
             code=500
         )
 
+
 if __name__ == '__main__':
-    func.run()
+    FUNC.run()

--- a/functions/ti-import-to-ng-siem/test_main.py
+++ b/functions/ti-import-to-ng-siem/test_main.py
@@ -1,8 +1,14 @@
-import pytest
-from unittest.mock import patch, MagicMock
+"""Unit tests for the TI feed importer function."""
+
 import csv
-import tempfile
+import importlib
 import os
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from crowdstrike.foundry.function import Request
 
 # Import the functions to test
 from main import (
@@ -11,13 +17,13 @@ from main import (
     FILES_TO_PROCESS
 )
 
-def mock_handler(*args, **kwargs):
+
+def mock_handler(*_args, **_kwargs):
+    """Mock decorator that replaces @FUNC.handler for testing."""
     def identity(func):
         return func
     return identity
 
-
-from crowdstrike.foundry.function import Request
 
 # Test data
 MOCK_IP_FILE_CONTENT = """
@@ -43,27 +49,26 @@ https://example.com/malware.exe
 https://malicious.com/backdoor.php
 """
 
-@pytest.fixture
-def mock_temp_dir():
-    """Fixture to create a temporary directory for testing"""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        yield temp_dir
+@pytest.fixture(name="temp_dir")
+def fixture_temp_dir():
+    """Fixture to create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield tmp
 
-@pytest.fixture
-def mock_requests_get():
-    """Fixture to mock requests.get"""
+@pytest.fixture(name="requests_get")
+def fixture_requests_get():
+    """Fixture to mock requests.get."""
     with patch('requests.get') as mock_get:
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
         yield mock_get, mock_response
 
-@pytest.fixture
-def mock_ngsiem():
-    """Fixture to mock NGSIEM client"""
+@pytest.fixture(name="ngsiem")
+def fixture_ngsiem():
+    """Fixture to mock NGSIEM client."""
     with patch('falconpy.NGSIEM') as mock_ngsiem_class:
         mock_instance = MagicMock()
-        # Mock successful upload response
         mock_instance.upload_file.return_value = {
             "status_code": 200,
             "body": {"message": "File uploaded successfully"}
@@ -72,7 +77,7 @@ def mock_ngsiem():
         yield mock_instance
 
 def test_is_valid_ipv4():
-    """Test IP validation function"""
+    """Test IP validation function."""
     # Valid IPs
     assert is_valid_ipv4("192.168.1.1") is True
     assert is_valid_ipv4("10.0.0.1") is True
@@ -86,9 +91,9 @@ def test_is_valid_ipv4():
     assert is_valid_ipv4("") is False
     assert is_valid_ipv4("2001:0db8:85a3:0000:0000:8a2e:0370:7334") is False  # IPv6
 
-def test_process_file_ip_with_separator(mock_requests_get, mock_temp_dir):
-    """Test processing IP file with separator"""
-    mock_get, mock_response = mock_requests_get
+def test_process_file_ip_with_separator(requests_get, temp_dir):
+    """Test processing IP file with separator."""
+    _, mock_response = requests_get
     mock_response.text = MOCK_IP_FILE_CONTENT
 
     file_info = {
@@ -98,25 +103,23 @@ def test_process_file_ip_with_separator(mock_requests_get, mock_temp_dir):
         "separator": " # "
     }
 
-    output_path = process_file(file_info, mock_temp_dir)
+    output_path = process_file(file_info, temp_dir)
 
-    # Verify the file was created
     assert os.path.exists(output_path)
 
-    # Verify content
-    with open(output_path, newline='') as csvfile:
+    with open(output_path, newline='', encoding='utf-8') as csvfile:
         reader = csv.reader(csvfile)
         rows = list(reader)
-    assert rows[0] == ["destination.ip", "destination.ip.details"]  # header
+    assert rows[0] == ["destination.ip", "destination.ip.details"]
     assert len(rows) == 3  # header + 2 data rows
     assert rows[1][0] == "192.168.1.1"
     assert rows[1][1] == ""  # no comment for first IP
     assert rows[2][0] == "10.0.0.1"
     assert rows[2][1] == "Some comment"
 
-def test_process_file_ip_without_separator(mock_requests_get, mock_temp_dir):
-    """Test processing IP file without separator"""
-    mock_get, mock_response = mock_requests_get
+def test_process_file_ip_without_separator(requests_get, temp_dir):
+    """Test processing IP file without separator."""
+    _, mock_response = requests_get
     mock_response.text = MOCK_IP_FILE_CONTENT
 
     file_info = {
@@ -126,19 +129,18 @@ def test_process_file_ip_without_separator(mock_requests_get, mock_temp_dir):
         "separator": None
     }
 
-    output_path = process_file(file_info, mock_temp_dir)
+    output_path = process_file(file_info, temp_dir)
 
-    # Verify content
-    with open(output_path, newline='') as csvfile:
+    with open(output_path, newline='', encoding='utf-8') as csvfile:
         reader = csv.reader(csvfile)
         rows = list(reader)
-    assert rows[0] == ["destination.ip"]  # header
+    assert rows[0] == ["destination.ip"]
     assert len(rows) == 2  # header + 1 data row
     assert rows[1][0] == "192.168.1.1"
 
-def test_process_file_domain(mock_requests_get, mock_temp_dir):
-    """Test processing domain file"""
-    mock_get, mock_response = mock_requests_get
+def test_process_file_domain(requests_get, temp_dir):
+    """Test processing domain file."""
+    _, mock_response = requests_get
     mock_response.text = MOCK_DOMAIN_FILE_CONTENT
 
     file_info = {
@@ -148,22 +150,21 @@ def test_process_file_domain(mock_requests_get, mock_temp_dir):
         "separator": " # domain - "
     }
 
-    output_path = process_file(file_info, mock_temp_dir)
+    output_path = process_file(file_info, temp_dir)
 
-    # Verify content
-    with open(output_path, newline='') as csvfile:
+    with open(output_path, newline='', encoding='utf-8') as csvfile:
         reader = csv.reader(csvfile)
         rows = list(reader)
-    assert rows[0] == ["dns.domain.name", "dns.domain.details"]  # header
+    assert rows[0] == ["dns.domain.name", "dns.domain.details"]
     assert len(rows) == 3  # header + 2 data rows
     assert rows[1][0] == "example.com"
     assert rows[1][1] == "Example Domain"
     assert rows[2][0] == "malicious.com"
     assert rows[2][1] == "Malicious Domain"
 
-def test_process_file_request_error(mock_requests_get, mock_temp_dir):
-    """Test handling of request errors"""
-    mock_get, mock_response = mock_requests_get
+def test_process_file_request_error(requests_get, temp_dir):
+    """Test handling of request errors."""
+    _, mock_response = requests_get
     mock_response.raise_for_status.side_effect = Exception("Failed to download")
 
     file_info = {
@@ -174,62 +175,51 @@ def test_process_file_request_error(mock_requests_get, mock_temp_dir):
     }
 
     with pytest.raises(Exception) as excinfo:
-        process_file(file_info, mock_temp_dir)
+        process_file(file_info, temp_dir)
 
     assert "Failed to download" in str(excinfo.value)
 
-def test_handler_success(mock_ngsiem):
-    """Test successful handler execution"""
-    # Create request
-    request = Request(
-        body={"repository": "custom-repo"},
-    )
 
-    # Create mock logger
+def _reload_main_with_mock_handler():
+    """Reload main module with mocked handler decorator."""
+    import main  # pylint: disable=import-outside-toplevel
+    importlib.reload(main)
+    return main
+
+
+def test_handler_success(ngsiem):
+    """Test successful handler execution."""
+    request = Request(body={"repository": "custom-repo"})
     mock_logger = MagicMock()
 
     with patch('crowdstrike.foundry.function.Function.handler', new=mock_handler):
-        import importlib
-        import main
-        importlib.reload(main)
+        main = _reload_main_with_mock_handler()
 
         with patch('os.path.exists') as mock_exists, \
                 patch('main.process_file') as mock_process_file:
             mock_exists.return_value = True
             mock_process_file.return_value = "/tmp/test_file.csv"
 
-            # execute handler
             response = main.next_gen_siem_csv_import(request, {}, mock_logger)
 
-            # Verify results
             assert response.code == 200
             assert "results" in response.body
             assert len(response.body["results"]) == len(FILES_TO_PROCESS)
-
-            # Verify all files were processed
             assert mock_process_file.call_count == len(FILES_TO_PROCESS)
-
-            # Verify NGSIEM upload was called
-            assert mock_ngsiem.upload_file.call_count == len(FILES_TO_PROCESS)
+            assert ngsiem.upload_file.call_count == len(FILES_TO_PROCESS)
 
 
-def test_handler_with_skipped_files(mock_ngsiem):
-    """Test handler with some feeds returning no data (skipped)"""
-    request = Request(
-        body={"repository": "custom-repo"},
-    )
-
+def test_handler_with_skipped_files(ngsiem):
+    """Test handler with some feeds returning no data (skipped)."""
+    request = Request(body={"repository": "custom-repo"})
     mock_logger = MagicMock()
 
     with patch('crowdstrike.foundry.function.Function.handler', new=mock_handler):
-        import importlib
-        import main
-        importlib.reload(main)
+        main = _reload_main_with_mock_handler()
 
         with patch('os.path.exists') as mock_exists, \
                 patch('main.process_file') as mock_process_file:
             mock_exists.return_value = True
-            # First two files return None (empty feeds), rest succeed
             mock_process_file.side_effect = [
                 None, None,
                 *["/tmp/test_file.csv"] * (len(FILES_TO_PROCESS) - 2)
@@ -239,117 +229,74 @@ def test_handler_with_skipped_files(mock_ngsiem):
 
             assert response.code == 200
             assert len(response.body["results"]) == len(FILES_TO_PROCESS)
-
-            # First two should be skipped
             assert response.body["results"][0]["status"] == "skipped"
             assert response.body["results"][1]["status"] == "skipped"
+            assert ngsiem.upload_file.call_count == len(FILES_TO_PROCESS) - 2
 
-            # NGSIEM upload should only be called for non-skipped files
-            assert mock_ngsiem.upload_file.call_count == len(FILES_TO_PROCESS) - 2
-
-def test_handler_with_processing_error(mock_ngsiem):
-    """Test handler with processing error for one file"""
-
-    # Create request
-    request = Request(
-        body={"repository": "custom-repo"},
-    )
-
-    # Create mock logger
+def test_handler_with_processing_error(ngsiem):
+    """Test handler with processing error for one file."""
+    request = Request(body={"repository": "custom-repo"})
     mock_logger = MagicMock()
 
     with patch('crowdstrike.foundry.function.Function.handler', new=mock_handler):
-        import importlib
-        import main
-        importlib.reload(main)
+        main = _reload_main_with_mock_handler()
 
-        # Setup mocks - first file fails, others succeed
         with patch('os.path.exists') as mock_exists, \
                 patch('main.process_file') as mock_process_file:
             mock_exists.return_value = True
             mock_process_file.side_effect = [
-                Exception("Failed to process"),  # First file fails
-                *["/tmp/test_file.csv"] * (len(FILES_TO_PROCESS) - 1)  # Rest succeed
+                RuntimeError("Failed to process"),
+                *["/tmp/test_file.csv"] * (len(FILES_TO_PROCESS) - 1)
             ]
 
-            # Execute handler
             response = main.next_gen_siem_csv_import(request, {}, mock_logger)
 
-            # Verify results
             assert response.code == 200
             assert "results" in response.body
             assert len(response.body["results"]) == len(FILES_TO_PROCESS)
-
-            # Verify first file has error
             assert response.body["results"][0]["status"] == "error"
             assert "Failed to process" in response.body["results"][0]["message"]
+            assert ngsiem.upload_file.call_count == len(FILES_TO_PROCESS) - 1
 
-            # Verify NGSIEM upload was called for successful files only
-            assert mock_ngsiem.upload_file.call_count == len(FILES_TO_PROCESS) - 1
-
-def test_handler_with_missing_files(mock_ngsiem):
-    """Test handler with processing error for all files"""
-
-    # Create request
-    request = Request(
-        body={"repository": "custom-repo"},
-    )
-
-    # Create mock logger
+def test_handler_with_missing_files(ngsiem):
+    """Test handler with processing error for all files."""
+    request = Request(body={"repository": "custom-repo"})
     mock_logger = MagicMock()
 
     with patch('crowdstrike.foundry.function.Function.handler', new=mock_handler):
-        import importlib
-        import main
-        importlib.reload(main)
+        main = _reload_main_with_mock_handler()
 
-        # Setup mocks - first file fails, others succeed
         with patch('os.path.exists') as mock_exists, \
                 patch('main.process_file') as mock_process_file:
             mock_exists.return_value = False
             mock_process_file.return_value = "/tmp/test_file.csv"
 
-            # Execute handler
             response = main.next_gen_siem_csv_import(request, {}, mock_logger)
 
-            # Verify results
             assert response.code == 200
             assert "results" in response.body
             assert len(response.body["results"]) == len(FILES_TO_PROCESS)
-
-            # Verify all files have error
             assert response.body["results"][0]["status"] == "error"
             assert response.body["results"][0]["message"] == "File does not exist"
+            assert ngsiem.upload_file.call_count == 0
 
-            # Verify NGSIEM upload was not called
-            assert mock_ngsiem.upload_file.call_count == 0
-
-def test_handler_global_exception(mock_ngsiem):
-    """Test handler with a global exception"""
-
-    # Create request that will cause an exception
-    request = Request(
-        body=None,  # This will cause an exception when trying to access .get()
-    )
-
-    # Create mock logger
+def test_handler_global_exception(ngsiem):  # pylint: disable=unused-argument
+    """Test handler with a global exception."""
+    request = Request(body=None)
     mock_logger = MagicMock()
 
     with patch('crowdstrike.foundry.function.Function.handler', new=mock_handler):
-        import importlib
-        import main
-        importlib.reload(main)
+        main = _reload_main_with_mock_handler()
 
         response = main.next_gen_siem_csv_import(request, {}, mock_logger)
-        # Verify error response
         assert response.code == 500
         assert len(response.errors) == 1
         assert response.errors[0].code == 500
 
 
-def test_process_file_empty_content(mock_requests_get, mock_temp_dir):
-    """Test processing empty file content"""
-    mock_get, mock_response = mock_requests_get
+def test_process_file_empty_content(requests_get, temp_dir):
+    """Test processing empty file content."""
+    _, mock_response = requests_get
     mock_response.text = ""
 
     file_info = {
@@ -359,15 +306,13 @@ def test_process_file_empty_content(mock_requests_get, mock_temp_dir):
         "separator": None
     }
 
-    output_path = process_file(file_info, mock_temp_dir)
-
-    # Empty feed should return None (no file created)
+    output_path = process_file(file_info, temp_dir)
     assert output_path is None
 
 
-def test_process_file_only_comments(mock_requests_get, mock_temp_dir):
-    """Test processing file with only comments"""
-    mock_get, mock_response = mock_requests_get
+def test_process_file_only_comments(requests_get, temp_dir):
+    """Test processing file with only comments."""
+    _, mock_response = requests_get
     mock_response.text = "# Comment 1\n# Comment 2\n"
 
     file_info = {
@@ -377,58 +322,36 @@ def test_process_file_only_comments(mock_requests_get, mock_temp_dir):
         "separator": None
     }
 
-    output_path = process_file(file_info, mock_temp_dir)
-
-    # Comment-only feed should return None (no file created)
+    output_path = process_file(file_info, temp_dir)
     assert output_path is None
 
-def test_handler_default_repository(mock_ngsiem):
-    """Test handler with default repository"""
-
-    # Create request with no repository specified
-    request = Request(
-        body={},  # No repository specified
-    )
-
-    # Create mock logger
+def test_handler_default_repository(ngsiem):
+    """Test handler with default repository."""
+    request = Request(body={})
     mock_logger = MagicMock()
 
-    # Setup mocks
     with patch('crowdstrike.foundry.function.Function.handler', new=mock_handler):
-        import importlib
-        import main
-        importlib.reload(main)
+        main = _reload_main_with_mock_handler()
 
         with patch('os.path.exists') as mock_exists, \
                 patch('main.process_file') as mock_process_file:
             mock_exists.return_value = True
             mock_process_file.return_value = "/tmp/test_file.csv"
 
-            # Execute handler
             response = main.next_gen_siem_csv_import(request, {}, mock_logger)
 
-            # Verify results
             assert response.code == 200
-
-            # Verify NGSIEM upload was called with default repository
-            mock_ngsiem.upload_file.assert_called_with(
+            ngsiem.upload_file.assert_called_with(
                 lookup_file="/tmp/test_file.csv",
-                repository="search-all"  # Default value
+                repository="search-all"
             )
 
-def test_handler_ngsiem_api_error(mock_ngsiem):
-    """Test handler with NGSIEM API error"""
-
-    # Create request
-    request = Request(
-        body={"repository": "custom-repo"},
-    )
-
-    # Create mock logger
+def test_handler_ngsiem_api_error(ngsiem):
+    """Test handler with NGSIEM API error."""
+    request = Request(body={"repository": "custom-repo"})
     mock_logger = MagicMock()
 
-    # Mock NGSIEM to return an error response
-    mock_ngsiem.upload_file.return_value = {
+    ngsiem.upload_file.return_value = {
         "status_code": 400,
         "error": {
             "message": "Invalid file format"
@@ -436,24 +359,19 @@ def test_handler_ngsiem_api_error(mock_ngsiem):
     }
 
     with patch('crowdstrike.foundry.function.Function.handler', new=mock_handler):
-        import importlib
-        import main
-        importlib.reload(main)
+        main = _reload_main_with_mock_handler()
 
         with patch('os.path.exists') as mock_exists, \
                 patch('main.process_file') as mock_process_file:
             mock_exists.return_value = True
             mock_process_file.return_value = "/tmp/test_file.csv"
 
-            # Execute handler
             response = main.next_gen_siem_csv_import(request, {}, mock_logger)
 
-            # Verify response is still successful (bulk processing continues despite individual errors)
             assert response.code == 200
             assert "results" in response.body
             assert len(response.body["results"]) == len(FILES_TO_PROCESS)
 
-            # Verify all files have error status due to NGSIEM API error
             for result in response.body["results"]:
                 assert result["status"] == 400
                 assert "NGSIEM upload error:" in result["message"]


### PR DESCRIPTION
Add a pylint GitHub Actions workflow and `.pylintrc` matching [foundry-sample-functions-python](https://github.com/CrowdStrike/foundry-sample-functions-python) and [FalconPy](https://github.com/CrowdStrike/falconpy). Both `main.py` and `test_main.py` score 10/10.

**Workflow (`.github/workflows/pylint.yml`):**
- Triggers on push/PR when Python files change
- Iterates over all `functions/*/` directories, installs deps, runs pylint
- Uses `--max-line-length=127 --disable=R0801 --py-version=3.13`

**Fixes in `main.py`:**
- Rename `func` to `FUNC` (UPPER_CASE constant convention)
- Reorder imports (stdlib before third-party)
- Add module and function docstrings
- Add request timeout, file encoding, raise-from chaining
- Extract `_process_lines_with_separator()` and `_process_lines_single_column()` helpers to reduce nesting
- Narrow exception types (`RuntimeError`, `OSError`, `RequestException` instead of bare `Exception`)

**Fixes in `test_main.py`:**
- Reorder imports and add module docstring
- Rename fixtures with `fixture_` prefix and `name=` parameter to avoid `redefined-outer-name`
- Extract `_reload_main_with_mock_handler()` to deduplicate `import-outside-toplevel`
- Add `encoding='utf-8'` to `open()` calls
- Use `_` prefix for unused fixture unpacking

All 14 unit tests pass.