### PR TITLE
Pin crowdstrike-falconpy to 1.6.2

### DIFF
--- a/functions/ti-import-to-ng-siem/requirements.txt
+++ b/functions/ti-import-to-ng-siem/requirements.txt
@@ -1,3 +1,3 @@
 crowdstrike-foundry-function==1.1.4
-crowdstrike-falconpy
+crowdstrike-falconpy==1.6.2
 ipaddress==1.0.23


### PR DESCRIPTION
Pins crowdstrike-falconpy to 1.6.2 in requirements.txt to prevent supply chain risks from unpinned packages and to enable dependabot to track version updates.